### PR TITLE
GameCube: ARAM sizse 12 -> 16 MB

### DIFF
--- a/articles/gamecube.Rmd.md
+++ b/articles/gamecube.Rmd.md
@@ -107,7 +107,7 @@ The result was a system organised with two main buses:
 
 Additionally, this design contains an additional (yet unusual) bus where more memory can be found:
 
-- The **Eastbridge**: It connects the GPU with another memory chip called **Audio RAM** or 'ARAM' [@cpu-hitmen]. It provides **12 MB of SRAM** available for general purpose, which is pretty big for *spare* memory. However, the bus is not accessible through normal means (memory addresses). Instead, it's connected to an 8-bit serial endpoint (clocked two times slower than the GPU and four times slower than the CPU), which is only accessible through DMA.
+- The **Eastbridge**: It connects the GPU with another memory chip called **Audio RAM** or 'ARAM' [@cpu-hitmen]. It provides **16 MB of SRAM** available for general purpose, which is pretty big for *spare* memory. However, the bus is not accessible through normal means (memory addresses). Instead, it's connected to an 8-bit serial endpoint (clocked two times slower than the GPU and four times slower than the CPU), which is only accessible through DMA.
 
 Overall, this means that while ARAM provides a considerable amount of RAM, it will be limited to less critical tasks, like acting as an audio buffer or being used by certain accessories (explained in the I/O section).
 


### PR DESCRIPTION
Updating what appears to be a typo for the ARAM size. 

Previously it was stated to be 12 MB, but I believe that it's true size is 16 MB. See this document: Architecture Guide SDK Version 20-APR-2004
https://ia803004.us.archive.org/16/items/GCNArchitectureGuide/Architecture%20Guide.pdf

Page I-1
![image](https://github.com/flipacholas/Architecture-of-consoles/assets/25259855/51ad9ed5-61d3-4416-af62-8822a154f47b)


Also, later in this article you even state "Finally, we have the Audio RAM (ARAM) block, which is a large (16 MB) but very slow spare memory that can be used to store raw sound data."